### PR TITLE
Fix issue #1: jobQueue active list displays job being processed

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -76,16 +76,19 @@ class Queue {
                             if (jobInstance.jobOptions.attempts && jobInstance.jobOptions.attempts > 1) {
                                 jobInstance.jobOptions.attempts--;
                                 const priority = jobInstance.jobOptions.priority || 999;
+                                await this.activeJobRemover(jobId);
                                 await this.redisClient.zAdd(`jobQueue:${this.name}:waiting`, [{ score: priority, value: jobId.toString() }]);
                                 console.log('Job failed, trying again:', jobId);
                             } else {
                                 await jobInstance.isFailed();
+                                await this.activeJobRemover(jobId);
                                 await this.jobDataUpdater(jobInstance, jobId);
                                 await this.jobFailedArrayUpdater(jobId);
                                 console.log('Job failed:', jobId);
                             }
                         } else {
                             await jobInstance.isCompleted();
+                            await this.activeJobRemover(jobId);
                             await this.jobDataUpdater(jobInstance, jobId);
                             await this.jobCompletedArrayUpdater(jobId);
                             console.log('Job completed:', jobId);
@@ -146,6 +149,7 @@ class Queue {
     async handleJob(jobId) {
         try {
             // Simulate job processing time
+            //let time = 1000 + Math.floor(Math.random() * 2000);
             await new Promise(resolve => setTimeout(resolve, 1000));
             //console.log('Job processed:', jobId);
         } catch (error) {
@@ -176,6 +180,14 @@ class Queue {
             await this.redisClient.lPush(`jobQueue:${this.name}:failed`, jobId.toString());
         } catch (error) {
             console.error('Error updating failed jobs array:', error);
+        }
+    }
+
+    async activeJobRemover(jobId) {
+        try {
+            await this.redisClient.lRem(`jobQueue:${this.name}:active`, 1, jobId.toString());
+        } catch (error) {
+            console.error('Error removing active job:', error);
         }
     }
 }


### PR DESCRIPTION
Job were being added by the worker processing the job, added a activeJobRemover function which removes the job when the done callback is called for both job completion and failure, resulting in jobQueue active list showing only the jobs being processed currently.